### PR TITLE
Improvement to money.exchange.ExchangeRates.install API.

### DIFF
--- a/src-py2/money/exchange.py
+++ b/src-py2/money/exchange.py
@@ -12,18 +12,18 @@ from .exceptions import ExchangeBackendNotInstalled
 class BackendBase():
     """Abstract base class API for exchange backends"""
     __metaclass__ = abc.ABCMeta
-    
+
     @property
     @abc.abstractmethod
     def base(self):
         """Return the base currency"""
         return
-    
+
     @abc.abstractmethod
     def rate(self, currency):
         """Return quotation between the base and another currency"""
         return None
-    
+
     @abc.abstractmethod
     def quotation(self, origin, target):
         """Return quotation between two currencies (origin, target)"""
@@ -38,25 +38,25 @@ class SimpleBackend(BackendBase):
     def __init__(self):
         self._base = None
         self._rates = {}
-    
+
     @property
     def base(self):
         return self._base
-    
+
     @base.setter
     def base(self, currency):
         self._base = currency
-    
+
     def setrate(self, currency, rate):
         if not self.base:
             raise Warning("set the base first: xrates.base = currency")
         self._rates[currency] = rate
-    
+
     def rate(self, currency):
         if currency == self.base:
             return decimal.Decimal(1)
         return self._rates.get(currency, None)
-    
+
     def quotation(self, origin, target):
         return super(SimpleBackend, self).quotation(origin, target)
 
@@ -64,55 +64,58 @@ class SimpleBackend(BackendBase):
 class ExchangeRates(object):
     def __init__(self):
         self._backend = None
-    
+
     def __nonzero__(self):
         return bool(self._backend)
-    
-    def install(self, pythonpath='money.exchange.SimpleBackend'):
+
+    def install(self, backend='money.exchange.SimpleBackend'):
         """Install an exchange rates backend using a python path string"""
-        path, name = pythonpath.rsplit('.', 1)
-        module = importlib.import_module(path)
-        backend = getattr(module, name)
-        if not issubclass(backend, BackendBase):
+        if isinstance(backend, basestring):
+            path, name = backend.rsplit('.', 1)
+            module = importlib.import_module(path)
+            backend = getattr(module, name)()
+        elif isinstance(backend, type):
+            backend = backend()
+        if not isinstance(backend, BackendBase):
             raise TypeError("backend '{}' is not a subclass of "
                             "money.xrates.BackendBase".format(backend))
-        self._backend = backend()
-    
+        self._backend = backend
+
     def uninstall(self):
         """Uninstall any exchange rates backend"""
         self._backend = None
-    
+
     @property
     def backend_name(self):
         """Return the class name of the currently installed backend or None"""
         if not self._backend:
             return None
         return self._backend.__class__.__name__
-    
+
     @property
     def base(self):
         """Return the base currency"""
         if not self._backend:
             raise ExchangeBackendNotInstalled()
         return self._backend.base
-    
+
     def rate(self, currency):
         """Return quotation between the base and another currency"""
         if not self._backend:
             raise ExchangeBackendNotInstalled()
         return self._backend.rate(currency)
-    
+
     def quotation(self, origin, target):
         """Return quotation between two currencies (origin, target)"""
         if not self._backend:
             raise ExchangeBackendNotInstalled()
         return self._backend.quotation(origin, target)
-    
+
     def __getattr__(self, name):
         if self._backend is None:
             raise ExchangeBackendNotInstalled()
         return getattr(self._backend, name)
-    
+
     def __setattr__(self, name, value):
         if name == '_backend':
             self.__dict__[name] = value

--- a/src-py2/money/tests/test_exchange.py
+++ b/src-py2/money/tests/test_exchange.py
@@ -7,6 +7,7 @@ from decimal import Decimal
 import unittest
 
 from money import Money, XMoney, xrates
+from money.exchange import SimpleBackend
 from money.exceptions import ExchangeBackendNotInstalled
 from money.exceptions import ExchangeRateNotFound
 
@@ -14,75 +15,87 @@ from money.exceptions import ExchangeRateNotFound
 class TestExchangeRatesSetup(unittest.TestCase):
     def setUp(self):
         xrates.uninstall()
-    
+
     def test_register(self):
         self.assertFalse(xrates)
         self.assertIsNone(xrates.backend_name)
         xrates.install('money.exchange.SimpleBackend')
         self.assertEqual(xrates.backend_name, 'SimpleBackend')
-    
+
+    def test_register_class(self):
+        self.assertFalse(xrates)
+        self.assertIsNone(xrates.backend_name)
+        xrates.install(SimpleBackend)
+        self.assertEqual(xrates.backend_name, 'SimpleBackend')
+
+    def test_register_instance(self):
+        self.assertFalse(xrates)
+        self.assertIsNone(xrates.backend_name)
+        xrates.install(SimpleBackend())
+        self.assertEqual(xrates.backend_name, 'SimpleBackend')
+
     def test_unregister(self):
         xrates.install('money.exchange.SimpleBackend')
         self.assertEqual(xrates.backend_name, 'SimpleBackend')
         xrates.uninstall()
         self.assertFalse(xrates)
         self.assertIsNone(xrates.backend_name)
-    
+
     def test_no_backend_name(self):
         self.assertIsNone(xrates.backend_name)
-    
+
     def test_no_backend_base(self):
         with self.assertRaises(ExchangeBackendNotInstalled):
             xrates.base
-    
+
     def test_no_backend_get_rate(self):
         with self.assertRaises(ExchangeBackendNotInstalled):
             xrates.rate('XXX')
-    
+
     def test_no_backend_get_quotation(self):
         with self.assertRaises(ExchangeBackendNotInstalled):
             xrates.quotation('XXX', 'YYY')
-    
+
     def test_multiple_xrates(self):
         xrates.install('money.exchange.SimpleBackend')
         self.assertTrue(xrates)
         xrates.base = 'XXX'
         xrates.setrate('AAA', Decimal('2'))
-        
+
         from money.exchange import ExchangeRates
         another = ExchangeRates()
         another.install('money.exchange.SimpleBackend')
         self.assertTrue(another)
         another.base = 'XXX'
         another.setrate('AAA', Decimal('100'))
-        
+
         self.assertEqual(xrates.rate('AAA'), Decimal('2'))
         self.assertEqual(another.rate('AAA'), Decimal('100'))
 
 
 class BackendTestBase():
     __metaclass__ = abc.ABCMeta
-    
+
     @abc.abstractmethod
     def test_base_property(self):
         pass
-    
+
     @abc.abstractmethod
     def test_rate(self):
         pass
-    
+
     @abc.abstractmethod
     def test_quotation(self):
         pass
-    
+
     @abc.abstractmethod
     def test_unavailable_rate_returns_none(self):
         pass
-    
+
     @abc.abstractmethod
     def test_unavailable_quotation_returns_none(self):
         pass
-    
+
     @abc.abstractmethod
     def test_money_conversion(self):
         pass
@@ -91,22 +104,22 @@ class BackendTestBase():
 class TestSimpleBackend(BackendTestBase, unittest.TestCase):
     def setUp(self):
         xrates.install('money.exchange.SimpleBackend')
-    
+
     def load_testing_data(self):
         xrates.base = 'XXX'
         xrates.setrate('AAA', Decimal('2'))
         xrates.setrate('BBB', Decimal('8'))
-    
+
     def test_base_property(self):
         self.load_testing_data()
         self.assertEqual(xrates.base, 'XXX')
-    
+
     def test_rate(self):
         self.load_testing_data()
         self.assertEqual(xrates.rate('XXX'), Decimal('1'))
         self.assertEqual(xrates.rate('AAA'), Decimal('2'))
         self.assertEqual(xrates.rate('BBB'), Decimal('8'))
-    
+
     def test_quotation(self):
         self.load_testing_data()
         self.assertEqual(xrates.quotation('XXX', 'XXX'), Decimal('1'))
@@ -118,20 +131,20 @@ class TestSimpleBackend(BackendTestBase, unittest.TestCase):
         self.assertEqual(xrates.quotation('BBB', 'XXX'), Decimal('0.125'))
         self.assertEqual(xrates.quotation('BBB', 'AAA'), Decimal('0.25'))
         self.assertEqual(xrates.quotation('BBB', 'BBB'), Decimal('1'))
-    
+
     def test_unavailable_rate_returns_none(self):
         self.load_testing_data()
         self.assertIsNone(xrates.rate('ZZZ'))
-    
+
     def test_unavailable_quotation_returns_none(self):
         self.load_testing_data()
         self.assertIsNone(xrates.quotation('YYY', 'ZZZ'))
-    
+
     def test_money_conversion(self):
         self.load_testing_data()
         self.assertEqual(Money('10', 'AAA').to('BBB'), Money('40', 'BBB'))
         self.assertEqual(Money('10', 'BBB').to('AAA'), Money('2.5', 'AAA'))
-    
+
     def test_base_not_set_warning(self):
         with self.assertRaises(Warning):
             xrates.setrate('AAA', Decimal('2'))
@@ -142,7 +155,7 @@ class ConversionMixin(object):
         xrates.uninstall()
         with self.assertRaises(ExchangeBackendNotInstalled):
             self.MoneyClass('2', 'AAA').to('BBB')
-    
+
     def test_unavailable_rate_conversion_error(self):
         xrates.install('money.exchange.SimpleBackend')
         with self.assertRaises(ExchangeRateNotFound):

--- a/src/money/exchange.py
+++ b/src/money/exchange.py
@@ -15,12 +15,12 @@ class BackendBase(metaclass=abc.ABCMeta):
     def base(self):
         """Return the base currency"""
         return
-    
+
     @abc.abstractmethod
     def rate(self, currency):
         """Return quotation between the base and another currency"""
         return None
-    
+
     @abc.abstractmethod
     def quotation(self, origin, target):
         """Return quotation between two currencies (origin, target)"""
@@ -35,25 +35,25 @@ class SimpleBackend(BackendBase):
     def __init__(self):
         self._base = None
         self._rates = {}
-    
+
     @property
     def base(self):
         return self._base
-    
+
     @base.setter
     def base(self, currency):
         self._base = currency
-    
+
     def setrate(self, currency, rate):
         if not self.base:
             raise Warning("set the base first: xrates.base = currency")
         self._rates[currency] = rate
-    
+
     def rate(self, currency):
         if currency == self.base:
             return decimal.Decimal(1)
         return self._rates.get(currency, None)
-    
+
     def quotation(self, origin, target):
         return super().quotation(origin, target)
 
@@ -61,55 +61,58 @@ class SimpleBackend(BackendBase):
 class ExchangeRates(object):
     def __init__(self):
         self._backend = None
-    
+
     def __bool__(self):
         return bool(self._backend)
-    
-    def install(self, pythonpath='money.exchange.SimpleBackend'):
+
+    def install(self, backend='money.exchange.SimpleBackend'):
         """Install an exchange rates backend using a python path string"""
-        path, name = pythonpath.rsplit('.', 1)
-        module = importlib.import_module(path)
-        backend = getattr(module, name)
-        if not issubclass(backend, BackendBase):
+        if isinstance(backend, str):
+            path, name = backend.rsplit('.', 1)
+            module = importlib.import_module(path)
+            backend = getattr(module, name)()
+        elif isinstance(backend, type):
+            backend = backend()
+        if not isinstance(backend, BackendBase):
             raise TypeError("backend '{}' is not a subclass of "
                             "money.xrates.BackendBase".format(backend))
-        self._backend = backend()
-    
+        self._backend = backend
+
     def uninstall(self):
         """Uninstall any exchange rates backend"""
         self._backend = None
-    
+
     @property
     def backend_name(self):
         """Return the class name of the currently installed backend or None"""
         if not self._backend:
             return None
         return self._backend.__class__.__name__
-    
+
     @property
     def base(self):
         """Return the base currency"""
         if not self._backend:
             raise ExchangeBackendNotInstalled()
         return self._backend.base
-    
+
     def rate(self, currency):
         """Return quotation between the base and another currency"""
         if not self._backend:
             raise ExchangeBackendNotInstalled()
         return self._backend.rate(currency)
-    
+
     def quotation(self, origin, target):
         """Return quotation between two currencies (origin, target)"""
         if not self._backend:
             raise ExchangeBackendNotInstalled()
         return self._backend.quotation(origin, target)
-    
+
     def __getattr__(self, name):
         if self._backend is None:
             raise ExchangeBackendNotInstalled()
         return getattr(self._backend, name)
-    
+
     def __setattr__(self, name, value):
         if name == '_backend':
             self.__dict__[name] = value

--- a/src/money/tests/test_exchange.py
+++ b/src/money/tests/test_exchange.py
@@ -6,6 +6,7 @@ from decimal import Decimal
 import unittest
 
 from money import Money, XMoney, xrates
+from money.exchange import SimpleBackend
 from money.exceptions import ExchangeBackendNotInstalled
 from money.exceptions import ExchangeRateNotFound
 
@@ -13,48 +14,60 @@ from money.exceptions import ExchangeRateNotFound
 class TestExchangeRatesSetup(unittest.TestCase):
     def setUp(self):
         xrates.uninstall()
-    
+
     def test_register(self):
         self.assertFalse(xrates)
         self.assertIsNone(xrates.backend_name)
         xrates.install('money.exchange.SimpleBackend')
         self.assertEqual(xrates.backend_name, 'SimpleBackend')
-    
+
+    def test_register_class(self):
+        self.assertFalse(xrates)
+        self.assertIsNone(xrates.backend_name)
+        xrates.install(SimpleBackend)
+        self.assertEqual(xrates.backend_name, 'SimpleBackend')
+
+    def test_register_instance(self):
+        self.assertFalse(xrates)
+        self.assertIsNone(xrates.backend_name)
+        xrates.install(SimpleBackend())
+        self.assertEqual(xrates.backend_name, 'SimpleBackend')
+
     def test_unregister(self):
         xrates.install('money.exchange.SimpleBackend')
         self.assertEqual(xrates.backend_name, 'SimpleBackend')
         xrates.uninstall()
         self.assertFalse(xrates)
         self.assertIsNone(xrates.backend_name)
-    
+
     def test_no_backend_name(self):
         self.assertIsNone(xrates.backend_name)
-    
+
     def test_no_backend_base(self):
         with self.assertRaises(ExchangeBackendNotInstalled):
             xrates.base
-    
+
     def test_no_backend_get_rate(self):
         with self.assertRaises(ExchangeBackendNotInstalled):
             xrates.rate('XXX')
-    
+
     def test_no_backend_get_quotation(self):
         with self.assertRaises(ExchangeBackendNotInstalled):
             xrates.quotation('XXX', 'YYY')
-    
+
     def test_multiple_xrates(self):
         xrates.install('money.exchange.SimpleBackend')
         self.assertTrue(xrates)
         xrates.base = 'XXX'
         xrates.setrate('AAA', Decimal('2'))
-        
+
         from money.exchange import ExchangeRates
         another = ExchangeRates()
         another.install('money.exchange.SimpleBackend')
         self.assertTrue(another)
         another.base = 'XXX'
         another.setrate('AAA', Decimal('100'))
-        
+
         self.assertEqual(xrates.rate('AAA'), Decimal('2'))
         self.assertEqual(another.rate('AAA'), Decimal('100'))
 
@@ -63,23 +76,23 @@ class BackendTestBase(metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def test_base_property(self):
         pass
-    
+
     @abc.abstractmethod
     def test_rate(self):
         pass
-    
+
     @abc.abstractmethod
     def test_quotation(self):
         pass
-    
+
     @abc.abstractmethod
     def test_unavailable_rate_returns_none(self):
         pass
-    
+
     @abc.abstractmethod
     def test_unavailable_quotation_returns_none(self):
         pass
-    
+
     @abc.abstractmethod
     def test_money_conversion(self):
         pass
@@ -88,22 +101,22 @@ class BackendTestBase(metaclass=abc.ABCMeta):
 class TestSimpleBackend(BackendTestBase, unittest.TestCase):
     def setUp(self):
         xrates.install('money.exchange.SimpleBackend')
-    
+
     def load_testing_data(self):
         xrates.base = 'XXX'
         xrates.setrate('AAA', Decimal('2'))
         xrates.setrate('BBB', Decimal('8'))
-    
+
     def test_base_property(self):
         self.load_testing_data()
         self.assertEqual(xrates.base, 'XXX')
-    
+
     def test_rate(self):
         self.load_testing_data()
         self.assertEqual(xrates.rate('XXX'), Decimal('1'))
         self.assertEqual(xrates.rate('AAA'), Decimal('2'))
         self.assertEqual(xrates.rate('BBB'), Decimal('8'))
-    
+
     def test_quotation(self):
         self.load_testing_data()
         self.assertEqual(xrates.quotation('XXX', 'XXX'), Decimal('1'))
@@ -115,20 +128,20 @@ class TestSimpleBackend(BackendTestBase, unittest.TestCase):
         self.assertEqual(xrates.quotation('BBB', 'XXX'), Decimal('0.125'))
         self.assertEqual(xrates.quotation('BBB', 'AAA'), Decimal('0.25'))
         self.assertEqual(xrates.quotation('BBB', 'BBB'), Decimal('1'))
-    
+
     def test_unavailable_rate_returns_none(self):
         self.load_testing_data()
         self.assertIsNone(xrates.rate('ZZZ'))
-    
+
     def test_unavailable_quotation_returns_none(self):
         self.load_testing_data()
         self.assertIsNone(xrates.quotation('YYY', 'ZZZ'))
-    
+
     def test_money_conversion(self):
         self.load_testing_data()
         self.assertEqual(Money('10', 'AAA').to('BBB'), Money('40', 'BBB'))
         self.assertEqual(Money('10', 'BBB').to('AAA'), Money('2.5', 'AAA'))
-    
+
     def test_base_not_set_warning(self):
         with self.assertRaises(Warning):
             xrates.setrate('AAA', Decimal('2'))
@@ -139,7 +152,7 @@ class ConversionMixin(object):
         xrates.uninstall()
         with self.assertRaises(ExchangeBackendNotInstalled):
             self.MoneyClass('2', 'AAA').to('BBB')
-    
+
     def test_unavailable_rate_conversion_error(self):
         xrates.install('money.exchange.SimpleBackend')
         with self.assertRaises(ExchangeRateNotFound):


### PR DESCRIPTION
Extend `money.exchange.ExchangeRates.install` to accept a class or instance in addition to the currently supported dotted Python path string.  This makes configuration at runtime a little easier in some cases.