### PR TITLE
Support for SQLAlchemy composite columns

### DIFF
--- a/src-py2/money/money.py
+++ b/src-py2/money/money.py
@@ -208,6 +208,9 @@ class Money(object):
     def __round__(self, ndigits=0):
         return self.__class__(round(self.amount, ndigits), self.currency)
     
+    def __composite_values__(self):
+        return self.amount, self.currency
+    
     def to(self, currency):
         """Return equivalent money object in another currency"""
         if currency == self.currency:

--- a/src-py2/money/tests/mixins.py
+++ b/src-py2/money/tests/mixins.py
@@ -353,6 +353,9 @@ class UnaryOperationsReturnNewMixin(object):
     
     def test_round(self):
         self.assertIsNot(round(self.money), self.money)
+    
+    def test_sqlalchemy_composite_values(self):
+        self.assertEqual((Decimal(2), 'XXX'), self.money.__composite_values__())
 
 
 class LeftmostTypePrevailsMixin(object):

--- a/src/money/money.py
+++ b/src/money/money.py
@@ -201,6 +201,9 @@ class Money(object):
     def __round__(self, ndigits=0):
         return self.__class__(round(self.amount, ndigits), self.currency)
     
+    def __composite_values__(self):
+        return self.amount, self.currency
+    
     def to(self, currency):
         """Return equivalent money object in another currency"""
         if currency == self.currency:

--- a/src/money/tests/mixins.py
+++ b/src/money/tests/mixins.py
@@ -350,6 +350,9 @@ class UnaryOperationsReturnNewMixin(object):
     
     def test_round(self):
         self.assertIsNot(round(self.money), self.money)
+    
+    def test_sqlalchemy_composite_values(self):
+        self.assertEqual((Decimal(2), 'XXX'), self.money.__composite_values__())
 
 
 class LeftmostTypePrevailsMixin(object):


### PR DESCRIPTION
Implementing `__composite_values__()` method is pretty trivial, but it makes `Money`/`XMoney` possible to work fantastically with SQLAlchemy through [composite columns][1]:

```python
class Product(Base):

    amount = Column(Numeric, nullable=False)
    currency = Column(String(3), nullable=False)
    price = composite(Money, amount, currency)
```

It even doesn’t need to depend on SQLAlchemy.  :smile:

Also, should it be documented in README.rst?

[1]: http://docs.sqlalchemy.org/en/rel_1_0/orm/composites.html