### PR TITLE
Avoid distutils deprecation warning + a few other small fixes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -121,7 +121,7 @@ Use ``format(locale=LC_NUMERIC, pattern=None, currency_digits=True, format_type=
     >>> m.format('en_US')
     '$1,234.57'
     >>> m.format('es_ES')
-    '1.234,57\xa0$'
+    '1.234,57\xa0US$'
 
 The character ``\xa0`` is an unicode non-breaking space. If no locale is passed, Babel will use your system's locale. You can also provide a specific pattern to format():
 

--- a/money/exchange.py
+++ b/money/exchange.py
@@ -70,11 +70,11 @@ class SimpleBackend(BackendBase):
 class ExchangeRates(object):
     def __init__(self):
         self._backend = None
-    
+
     # RADAR: Python2
     def __nonzero__(self):
         return self.__bool__()
-    
+
     def __bool__(self):
         return bool(self._backend)
 

--- a/money/money.py
+++ b/money/money.py
@@ -44,7 +44,7 @@ except ImportError:
 
 class Money(object):
     """Money class with a decimal amount and a currency"""
-    
+
     def __init__(self, amount="0", currency=None):
         try:
             self._amount = decimal.Decimal(amount)
@@ -58,31 +58,31 @@ class Money(object):
             raise ValueError("currency not in ISO 4217 format: "
                              "'{}'".format(currency))
         self._currency = currency
-    
+
     @property
     def amount(self):
         return self._amount
-    
+
     @property
     def currency(self):
         return self._currency
-    
+
     def __hash__(self):
         return hash((self._amount, self._currency))
-    
+
     def __repr__(self):
         return "{} {}".format(self._currency, self._amount)
-    
+
     def __str__(self):
         # RADAR: Python2
         if money.six.PY2:
             return self.__unicode__().encode('utf-8')
         return self.__unicode__()
-    
+
     # RADAR: Python2
     def __unicode__(self):
         return u"{} {:,.2f}".format(self._currency, self._amount)
-    
+
     def __lt__(self, other):
         if not isinstance(other, Money):
             raise InvalidOperandType(other, '<')
@@ -90,7 +90,7 @@ class Money(object):
             raise CurrencyMismatch(self._currency, other.currency, '<')
         else:
             return self._amount < other.amount
-    
+
     def __le__(self, other):
         if not isinstance(other, Money):
             raise InvalidOperandType(other, '<=')
@@ -98,16 +98,16 @@ class Money(object):
             raise CurrencyMismatch(self._currency, other.currency, '<=')
         else:
             return self._amount <= other.amount
-    
+
     def __eq__(self, other):
         if isinstance(other, Money):
             return ((self._amount == other.amount) and
                     (self._currency == other.currency))
         return False
-    
+
     def __ne__(self, other):
         return not self == other
-    
+
     def __gt__(self, other):
         if not isinstance(other, Money):
             raise InvalidOperandType(other, '>')
@@ -115,7 +115,7 @@ class Money(object):
             raise CurrencyMismatch(self._currency, other.currency, '>')
         else:
             return self._amount > other.amount
-    
+
     def __ge__(self, other):
         if not isinstance(other, Money):
             raise InvalidOperandType(other, '>=')
@@ -123,20 +123,20 @@ class Money(object):
             raise CurrencyMismatch(self._currency, other.currency, '>=')
         else:
             return self._amount >= other.amount
-    
+
     # RADAR: Python2
     def __nonzero__(self):
         return self.__bool__()
-    
+
     def __bool__(self):
         """
         Considering Money a numeric type (on ``amount``):
-        
+
         bool(Money(2, 'XXX')) --> True
         bool(Money(0, 'XXX')) --> False
         """
         return bool(self._amount)
-    
+
     def __add__(self, other):
         if isinstance(other, Money):
             if other.currency != self._currency:
@@ -144,10 +144,10 @@ class Money(object):
             other = other.amount
         amount = self._amount + other
         return self.__class__(amount, self._currency)
-    
+
     def __radd__(self, other):
         return self.__add__(other)
-    
+
     def __sub__(self, other):
         if isinstance(other, Money):
             if other.currency != self._currency:
@@ -155,24 +155,24 @@ class Money(object):
             other = other.amount
         amount = self._amount - other
         return self.__class__(amount, self._currency)
-    
+
     def __rsub__(self, other):
         return (-self).__add__(other)
-    
+
     def __mul__(self, other):
         if isinstance(other, Money):
             raise TypeError("multiplication is unsupported between "
                             "two money objects")
         amount = self._amount * other
         return self.__class__(amount, self._currency)
-    
+
     def __rmul__(self, other):
         return self.__mul__(other)
-    
+
     # RADAR: Python2
     def __div__(self, other):
         return self.__truediv__(other)
-    
+
     def __truediv__(self, other):
         if isinstance(other, Money):
             if other.currency != self._currency:
@@ -185,7 +185,7 @@ class Money(object):
                 raise ZeroDivisionError()
             amount = self._amount / other
             return self.__class__(amount, self._currency)
-    
+
     def __floordiv__(self, other):
         if isinstance(other, Money):
             if other.currency != self._currency:
@@ -198,7 +198,7 @@ class Money(object):
                 raise ZeroDivisionError()
             amount = self._amount // other
             return self.__class__(amount, self._currency)
-    
+
     def __mod__(self, other):
         if isinstance(other, Money):
             raise TypeError("modulo is unsupported between two '{}' "
@@ -207,7 +207,7 @@ class Money(object):
             raise ZeroDivisionError()
         amount = self._amount % other
         return self.__class__(amount, self._currency)
-    
+
     def __divmod__(self, other):
         if isinstance(other, Money):
             if other.currency != self._currency:
@@ -221,35 +221,35 @@ class Money(object):
             whole, remainder = divmod(self._amount, other)
             return (self.__class__(whole, self._currency),
                     self.__class__(remainder, self._currency))
-    
+
     def __pow__(self, other):
         if isinstance(other, Money):
             raise TypeError("power operator is unsupported between two '{}' "
                             "objects".format(self.__class__.__name__))
         amount = self._amount ** other
         return self.__class__(amount, self._currency)
-    
+
     def __neg__(self):
         return self.__class__(-self._amount, self._currency)
-    
+
     def __pos__(self):
         return self.__class__(+self._amount, self._currency)
-    
+
     def __abs__(self):
         return self.__class__(abs(self._amount), self._currency)
-        
+
     def __int__(self):
         return int(self._amount)
-    
+
     def __float__(self):
         return float(self._amount)
-    
+
     def __round__(self, ndigits=0):
         return self.__class__(round(self._amount, ndigits), self._currency)
-    
+
     def __composite_values__(self):
         return self._amount, self._currency
-    
+
     def to(self, currency):
         """Return equivalent money object in another currency"""
         if currency == self._currency:
@@ -260,21 +260,21 @@ class Money(object):
                                          self._currency, currency)
         amount = self._amount * rate
         return self.__class__(amount, currency)
-    
+
     def format(self, locale=LC_NUMERIC, pattern=None, currency_digits=True,
                format_type='standard'):
         """
         Return a locale-aware, currency-formatted string.
-        
+
         This method emulates babel.numbers.format_currency().
-        
+
         A specific locale identifier (language[_territory]) can be passed,
         otherwise the system's default locale will be used. A custom
         formatting pattern of the form "¤#,##0.00;(¤#,##0.00)"
         (positive[;negative]) can also be passed, otherwise it will be
         determined from the locale and the CLDR (Unicode Common Locale Data
         Repository) included with Babel.
-        
+
         >>> m = Money('1234.567', 'EUR')
         >>> m.format() # assuming the system's locale is 'en_US'
         €1,234.57
@@ -284,7 +284,7 @@ class Money(object):
         1.235 €
         >>> m.format(pattern='#,##0.00 ¤¤¤') # Default locale, full name
         1,235.57 euro
-        
+
         Learn more about this formatting syntaxis at:
         http://www.unicode.org/reports/tr35/tr35-numbers.html
         """
@@ -298,7 +298,7 @@ class Money(object):
         else:
             raise NotImplementedError("formatting requires Babel "
                                       "(https://pypi.python.org/pypi/Babel)")
-    
+
     @classmethod
     def loads(cls, s):
         """Parse from a string representation (repr)"""
@@ -317,28 +317,28 @@ class XMoney(Money):
         if isinstance(other, Money):
             other = other.to(self._currency)
         return super(XMoney, self).__add__(other)
-    
+
     def __sub__(self, other):
         if isinstance(other, Money):
             other = other.to(self._currency)
         return super(XMoney, self).__sub__(other)
-    
+
     # RADAR: Python2
     def __div__(self, other):
         if isinstance(other, Money):
             other = other.to(self._currency)
         return super(XMoney, self).__div__(other)
-    
+
     def __truediv__(self, other):
         if isinstance(other, Money):
             other = other.to(self._currency)
         return super(XMoney, self).__truediv__(other)
-    
+
     def __floordiv__(self, other):
         if isinstance(other, Money):
             other = other.to(self._currency)
         return super(XMoney, self).__floordiv__(other)
-    
+
     def __divmod__(self, other):
         if isinstance(other, Money):
             other = other.to(self._currency)

--- a/money/money.py
+++ b/money/money.py
@@ -7,7 +7,6 @@ from __future__ import absolute_import
 
 import decimal
 import re
-from distutils.version import StrictVersion
 
 # RADAR: Python2
 import money.six
@@ -25,10 +24,19 @@ REGEX_CURRENCY_CODE = re.compile("^[A-Z]{3}$")
 LC_NUMERIC = None
 
 try:
+    from packaging import version
+    def make_version(v):
+        return version.parse(v)
+except ImportError:
+    from distutils.version import StrictVersion
+    def make_version(v):
+        return StrictVersion(v)
+
+try:
     import babel
     import babel.numbers
     BABEL_AVAILABLE = True
-    BABEL_VERSION = StrictVersion(babel.__version__)
+    BABEL_VERSION = make_version(babel.__version__)
     LC_NUMERIC = babel.default_locale('LC_NUMERIC')
 except ImportError:
     pass
@@ -281,7 +289,7 @@ class Money(object):
         http://www.unicode.org/reports/tr35/tr35-numbers.html
         """
         if BABEL_AVAILABLE:
-            if BABEL_VERSION < StrictVersion('2.2'):
+            if BABEL_VERSION < make_version('2.2'):
                 raise Exception('Babel {} is unsupported. '
                     'Please upgrade to 2.2 or higher.'.format(BABEL_VERSION))
             return babel.numbers.format_currency(

--- a/money/tests/mixins.py
+++ b/money/tests/mixins.py
@@ -27,35 +27,35 @@ class InstantiationMixin(object):
     def test_new_instance_int_amount(self):
         self.assertEqual(self.MoneyClass(0, 'XXX').amount, Decimal('0.00'))
         self.assertEqual(self.MoneyClass(2, 'XXX').amount, Decimal('2.00'))
-    
+
     def test_new_instance_decimal_amount(self):
         self.assertEqual(self.MoneyClass(Decimal('0.00'), 'XXX').amount, Decimal('0.00'))
         self.assertEqual(self.MoneyClass(Decimal('2.99'), 'XXX').amount, Decimal('2.99'))
-    
+
     def test_new_instance_float_amount(self):
         self.assertEqual(self.MoneyClass(0.0, 'XXX').amount, Decimal('0.00'))
         self.assertAlmostEqual(self.MoneyClass(2.99, 'XXX').amount, Decimal('2.99'))
-    
+
     def test_new_instance_str_amount(self):
         self.assertEqual(self.MoneyClass('0', 'XXX').amount, Decimal('0.00'))
         self.assertEqual(self.MoneyClass('2.99', 'XXX').amount, Decimal('2.99'))
-    
+
     def test_invalid_currency_missing(self):
         with self.assertRaises(ValueError):
             self.MoneyClass('2.99')
-    
+
     def test_invalid_currency_none(self):
         with self.assertRaises(ValueError):
             self.MoneyClass('2.99', None)
-    
+
     def test_invalid_currency_false(self):
         with self.assertRaises(ValueError):
             self.MoneyClass('2.99', False)
-    
+
     def test_invalid_currency_empty(self):
         with self.assertRaises(ValueError):
             self.MoneyClass('2.99', '')
-    
+
     def test_invalid_currency_code(self):
         with self.assertRaises(ValueError):
             self.MoneyClass('2.99', 'XX')
@@ -67,7 +67,7 @@ class InstantiationMixin(object):
             self.MoneyClass('2.99', '$')
         with self.assertRaises(ValueError):
             self.MoneyClass('2.99', 'US$')
-    
+
     def test_invalid_amount(self):
         with self.assertRaises(ValueError):
             self.MoneyClass('twenty', 'XXX')
@@ -76,26 +76,26 @@ class InstantiationMixin(object):
 class ClassMixin(object):
     def test_is_money(self):
         self.assertIsInstance(self.money, Money)
-    
+
     def test_immutable_by_convention(self):
         with self.assertRaises(AttributeError):
             self.money.amount += 1
         with self.assertRaises(AttributeError):
             self.money.currency = 'YYY'
-    
+
     def test_hashable(self):
         self.assertIsInstance(self.money, Hashable)
-    
+
     def test_hash_eq(self):
         money_set = set([self.money, self.money])
         self.assertEqual(len(money_set), 1)
-    
+
     def test_hash_int(self):
         self.assertEqual(type(hash(self.money)), int)
-    
+
     def test_pickable(self):
         self.assertEqual(pickle.loads(pickle.dumps(self.money)), self.money)
-    
+
     def test_sqlalchemy_composite_values(self):
         self.assertEqual((self.money.amount, self.money.currency), self.money.__composite_values__())
 
@@ -103,7 +103,7 @@ class ClassMixin(object):
 class RepresentationsMixin(object):
     def test_repr(self):
         self.assertEqual(repr(self.money), 'XXX 1234.567')
-    
+
     def test_str(self):
         self.assertEqual(str(self.money), 'XXX 1,234.57')
 
@@ -112,34 +112,34 @@ class RepresentationsMixin(object):
 class FormattingMixin(object):
     def test_custom_format_padding(self):
         self.assertEqual(self.money.format('en_US', u'¤000000.00'), u'-$001234.57')
-    
+
     def test_custom_format_custom_negative(self):
         self.assertEqual(self.money.format('en_US', u'¤#,##0.00;<¤#,##0.00>'), u'<$1,234.57>')
-    
+
     def test_custom_format_grouping(self):
         self.assertEqual(self.money.format('en_US', u'¤#,##0.00'), u'-$1,234.57')
         self.assertEqual(self.money.format('de_DE', u'#,##0.00 ¤'), u'-1.234,57 $')
         self.assertEqual(self.money.format('en_US', u'¤0.00'), u'-$1234.57')
         self.assertEqual(self.money.format('de_DE', u'0.00 ¤'), u'-1234,57 $')
-    
+
     def test_custom_format_decimals(self):
         self.assertEqual(self.money.format('en_US', u'¤0.000', currency_digits=False), u'-$1234.567')
         self.assertEqual(self.money.format('en_US', u'¤0', currency_digits=False), u'-$1235')
-    
+
     def test_auto_format_locales(self):
         self.assertEqual(self.money.format('en_US'), u'-$1,234.57')
         self.assertEqual(self.money.format('de_DE'), u'-1.234,57\xa0$')
         self.assertEqual(self.money.format('es_CO'), u'-US$1.234,57')
-    
+
     def test_auto_format_locales_alias(self):
         self.assertEqual(self.money.format('en'), self.money.format('en_US'))
         self.assertEqual(self.money.format('de'), self.money.format('de_DE'))
-    
+
     def test_auto_format_locale_numeric(self):
         locale = babel.default_locale('LC_NUMERIC')
         babel_formatted = babel.numbers.format_currency(self.money.amount, self.money.currency, locale=locale)
         self.assertEqual(self.money.format(), babel_formatted)
-    
+
     def test_auto_format(self):
         babel_formatted = babel.numbers.format_currency(self.money.amount, self.money.currency)
         self.assertEqual(self.money.format(), babel_formatted)
@@ -148,15 +148,15 @@ class FormattingMixin(object):
 class ParserMixin(object):
     def test_loads_repr(self):
         self.assertEqual(self.MoneyClass.loads('XXX 2.99'), self.MoneyClass('2.99', 'XXX'))
-    
+
     def test_loads_missing_currency(self):
         with self.assertRaises(ValueError):
             self.MoneyClass.loads('2.99')
-    
+
     def test_loads_reversed_order(self):
         with self.assertRaises(ValueError):
             self.MoneyClass.loads('2.99 XXX')
-    
+
     def test_loads_empty(self):
         with self.assertRaises(ValueError):
             self.MoneyClass.loads('')
@@ -167,271 +167,271 @@ class NumericOperationsMixin(object):
         self.assertTrue(self.MoneyClass('2.219', 'XXX') < self.MoneyClass('2.99', 'XXX'))
         self.assertTrue(self.MoneyClass('-2.99', 'XXX') < self.MoneyClass('2.99', 'XXX'))
         self.assertFalse(self.MoneyClass('0', 'XXX') < self.MoneyClass('0', 'XXX'))
-    
+
     def test_lt_works_only_with_money(self):
         with self.assertRaises(InvalidOperandType):
             self.MoneyClass(0, 'XXX') < Decimal('0')
-    
+
     def test_lt_money_different_currency(self):
         with self.assertRaises(CurrencyMismatch):
             self.MoneyClass(2, 'AAA') < self.MoneyClass(2, 'BBB')
-    
+
     def test_le(self):
         self.assertTrue(self.MoneyClass('2.219', 'XXX') <= self.MoneyClass('2.99', 'XXX'))
         self.assertTrue(self.MoneyClass('-2.99', 'XXX') <= self.MoneyClass('2.99', 'XXX'))
         self.assertTrue(self.MoneyClass('0', 'XXX') <= self.MoneyClass('0', 'XXX'))
         self.assertTrue(self.MoneyClass('2.990', 'XXX') <= self.MoneyClass('2.99', 'XXX'))
-    
+
     def test_le_works_only_with_money(self):
         with self.assertRaises(InvalidOperandType):
             self.MoneyClass(0, 'XXX') <= Decimal('0')
-    
+
     def test_le_money_different_currency(self):
         with self.assertRaises(CurrencyMismatch):
             self.MoneyClass(2, 'AAA') <= self.MoneyClass(2, 'BBB')
-    
+
     def test_eq(self):
         self.assertEqual(self.MoneyClass('2', 'XXX'), self.MoneyClass('2', 'XXX'))
         self.assertEqual(hash(self.MoneyClass('2', 'XXX')), hash(self.MoneyClass('2', 'XXX')))
-        
+
         self.assertEqual(self.MoneyClass('2.99000', 'XXX'), self.MoneyClass('2.99', 'XXX'))
         self.assertEqual(hash(self.MoneyClass('2.99000', 'XXX')), hash(self.MoneyClass('2.99', 'XXX')))
-    
+
     def test_ne(self):
         self.assertNotEqual(self.MoneyClass('0', 'XXX'), self.MoneyClass('2', 'XXX'))
         self.assertNotEqual(hash(self.MoneyClass('0', 'XXX')), hash(self.MoneyClass('2', 'XXX')))
-        
+
         self.assertNotEqual(self.MoneyClass('2.99001', 'XXX'), self.MoneyClass('2.99', 'XXX'))
         self.assertNotEqual(hash(self.MoneyClass('2.99001', 'XXX')), hash(self.MoneyClass('2.99', 'XXX')))
-        
+
         self.assertNotEqual(self.MoneyClass('2', 'XXX'), self.MoneyClass('2', 'YYY'))
         self.assertNotEqual(hash(self.MoneyClass('2', 'XXX')), hash(self.MoneyClass('2', 'YYY')))
-    
+
     def test_ne_if_not_money(self):
         self.assertNotEqual(self.MoneyClass(0, 'XXX'), Decimal('0'))
-    
+
     def test_gt(self):
         self.assertTrue(self.MoneyClass('2.99', 'XXX') > self.MoneyClass('2.219', 'XXX'))
         self.assertTrue(self.MoneyClass('2.99', 'XXX') > self.MoneyClass('-2.99', 'XXX'))
         self.assertFalse(self.MoneyClass('0', 'XXX') > self.MoneyClass('0', 'XXX'))
-    
+
     def test_gt_works_only_with_money(self):
         with self.assertRaises(InvalidOperandType):
             self.MoneyClass(0, 'XXX') > Decimal('0')
-    
+
     def test_gt_money_different_currency(self):
         with self.assertRaises(CurrencyMismatch):
             self.MoneyClass(2, 'AAA') > self.MoneyClass(2, 'BBB')
-    
+
     def test_ge(self):
         self.assertTrue(self.MoneyClass('2.99', 'XXX') >= self.MoneyClass('2.219', 'XXX'))
         self.assertTrue(self.MoneyClass('2.99', 'XXX') >= self.MoneyClass('-2.99', 'XXX'))
         self.assertTrue(self.MoneyClass('2.99', 'XXX') >= self.MoneyClass('2.99', 'XXX'))
-    
+
     def test_ge_works_only_with_money(self):
         with self.assertRaises(InvalidOperandType):
             self.MoneyClass(0, 'XXX') >= Decimal('0')
-    
+
     def test_ge_money_different_currency(self):
         with self.assertRaises(CurrencyMismatch):
             self.MoneyClass(2, 'AAA') >= self.MoneyClass(2, 'BBB')
-    
+
     def test_bool_true(self):
         self.assertTrue(self.MoneyClass('2.99', 'XXX'))
         self.assertTrue(self.MoneyClass('-1', 'XXX'))
-    
+
     def test_bool_false(self):
         self.assertFalse(self.MoneyClass('0', 'XXX'))
-    
+
     def test_add_int(self):
         result = self.MoneyClass('2', 'XXX') + 2
         self.assertEqual(result, self.MoneyClass('4', 'XXX'))
-    
+
     def test_add_decimal(self):
         result = self.MoneyClass('2', 'XXX') + Decimal('2')
         self.assertEqual(result, self.MoneyClass('4', 'XXX'))
-    
+
     def test_add_money(self):
         result = self.MoneyClass('2', 'XXX') + self.MoneyClass('2', 'XXX')
         self.assertEqual(result, self.MoneyClass('4', 'XXX'))
-    
+
     def test_add_money_different_currency(self):
         with self.assertRaises(CurrencyMismatch):
             self.MoneyClass(2, 'AAA') + self.MoneyClass(2, 'BBB')
-    
+
     def test_add_none(self):
         with self.assertRaises(TypeError):
             self.MoneyClass(0, 'XXX') + None
-    
+
     def test_radd_int(self):
         result = 2 + self.MoneyClass('2', 'XXX')
         self.assertEqual(result, self.MoneyClass('4', 'XXX'))
-    
+
     def test_sub_int(self):
         result = self.MoneyClass('2', 'XXX') - 2
         self.assertEqual(result, self.MoneyClass('0', 'XXX'))
-    
+
     def test_sub_decimal(self):
         result = self.MoneyClass('2', 'XXX') - Decimal(2)
         self.assertEqual(result, self.MoneyClass('0', 'XXX'))
-    
+
     def test_sub_money(self):
         result = self.MoneyClass('2', 'XXX') - self.MoneyClass('2', 'XXX')
         self.assertEqual(result, self.MoneyClass('0', 'XXX'))
-    
+
     def test_sub_money_different_currency(self):
         with self.assertRaises(CurrencyMismatch):
             self.MoneyClass(2, 'AAA') - self.MoneyClass(2, 'BBB')
-    
+
     def test_sub_none(self):
         with self.assertRaises(TypeError):
             self.MoneyClass(0, 'XXX') - None
-    
+
     def test_rsub_int(self):
         result = 0 - self.MoneyClass('2', 'XXX')
         self.assertEqual(result, self.MoneyClass('-2', 'XXX'))
-    
+
     def test_mul_int(self):
         result = self.MoneyClass('2', 'XXX') * 2
         self.assertEqual(result, self.MoneyClass('4', 'XXX'))
-    
+
     def test_mul_decimal(self):
         result = self.MoneyClass('2', 'XXX') * Decimal(2)
         self.assertEqual(result, self.MoneyClass('4', 'XXX'))
-    
+
     def test_mul_money(self):
         with self.assertRaises(TypeError):
             self.MoneyClass('2', 'XXX') * self.MoneyClass('2', 'XXX')
-    
+
     def test_mul_none(self):
         with self.assertRaises(TypeError):
             self.MoneyClass(0, 'XXX') * None
-    
+
     def test_rmul_int(self):
         result = 2 * self.MoneyClass('2', 'XXX')
         self.assertEqual(result, self.MoneyClass('4', 'XXX'))
-    
+
     def test_truediv_int(self):
         result = self.MoneyClass('2.99', 'XXX') / 2
         self.assertEqual(result, self.MoneyClass('1.495', 'XXX'))
-    
+
     def test_truediv_decimal(self):
         result = self.MoneyClass('2.99', 'XXX') / Decimal(2)
         self.assertEqual(result, self.MoneyClass('1.495', 'XXX'))
-    
+
     def test_truediv_money(self):
         result = self.MoneyClass('2', 'XXX') / self.MoneyClass('2', 'XXX')
         self.assertEqual(result, Decimal('1'))
-    
+
     def test_truediv_money_different_currency(self):
         with self.assertRaises(CurrencyMismatch):
             self.MoneyClass(2, 'AAA') / self.MoneyClass(2, 'BBB')
-    
+
     def test_truediv_none(self):
         with self.assertRaises(TypeError):
             self.MoneyClass(2, 'XXX') / None
-    
+
     def test_truediv_zero(self):
         with self.assertRaises(ZeroDivisionError):
             self.MoneyClass(2, 'XXX') / 0
-    
+
     def test_floordiv_number(self):
         result = self.MoneyClass('2.99', 'XXX') // 2
         self.assertEqual(result, self.MoneyClass('1', 'XXX'))
-    
+
     def test_floordiv_money(self):
         result = self.MoneyClass('2.99', 'XXX') // self.MoneyClass('2', 'XXX')
         self.assertEqual(result, Decimal('1'))
-    
+
     def test_floordiv_money_different_currency(self):
         with self.assertRaises(CurrencyMismatch):
             self.MoneyClass('2.99', 'AAA') // self.MoneyClass('2', 'BBB')
-    
+
     def test_floordiv_none(self):
         with self.assertRaises(TypeError):
             self.MoneyClass(2, 'XXX') // None
-    
+
     def test_floordiv_zero(self):
         with self.assertRaises(ZeroDivisionError):
             self.MoneyClass(2, 'XXX') // 0
-    
+
     def test_mod_number(self):
         result = self.MoneyClass('2.99', 'XXX') % 2
         self.assertEqual(result, self.MoneyClass('0.99', 'XXX'))
-    
+
     def test_mod_money(self):
         with self.assertRaises(TypeError):
             self.MoneyClass('2.99', 'XXX') % self.MoneyClass('2', 'XXX')
-    
+
     def test_mod_none(self):
         with self.assertRaises(TypeError):
             self.MoneyClass(2, 'XXX') % None
-    
+
     def test_mod_zero(self):
         with self.assertRaises(ZeroDivisionError):
             self.MoneyClass(2, 'XXX') % 0
-    
+
     def test_divmod_number(self):
         whole, remainder = divmod(self.MoneyClass('2.99', 'XXX'), 2)
         self.assertEqual(whole, self.MoneyClass('1', 'XXX'))
         self.assertEqual(remainder, self.MoneyClass('0.99', 'XXX'))
-    
+
     def test_divmod_money(self):
         whole, remainder = divmod(self.MoneyClass('2.99', 'XXX'), self.MoneyClass('2', 'XXX'))
         self.assertEqual(whole, Decimal('1'))
         self.assertEqual(remainder, Decimal('0.99'))
-    
+
     def test_divmod_money_different_currency(self):
         with self.assertRaises(CurrencyMismatch):
             divmod(self.MoneyClass('2.99', 'AAA'), self.MoneyClass('2', 'BBB'))
-    
+
     def test_divmod_none(self):
         with self.assertRaises(TypeError):
             divmod(self.MoneyClass(2, 'XXX'), None)
-    
+
     def test_divmod_zero(self):
         with self.assertRaises(ZeroDivisionError):
             divmod(self.MoneyClass(2, 'XXX'), 0)
-    
+
     def test_pow_number(self):
         result = self.MoneyClass('3', 'XXX') ** 2
         self.assertEqual(result, self.MoneyClass('9', 'XXX'))
-    
+
     def test_pow_money(self):
         with self.assertRaises(TypeError):
             self.MoneyClass('3', 'XXX') ** self.MoneyClass('2', 'XXX')
-    
+
     def test_pow_none(self):
         with self.assertRaises(TypeError):
             self.MoneyClass(0, 'XXX') ** None
-    
+
     def test_neg(self):
         result = -self.MoneyClass('2.99', 'XXX')
         self.assertEqual(result, self.MoneyClass('-2.99', 'XXX'))
-    
+
     def test_pos(self):
         result = +self.MoneyClass('2.99', 'XXX')
         self.assertEqual(result, self.MoneyClass('2.99', 'XXX'))
-    
+
     def test_abs(self):
         result = abs(self.MoneyClass('-2.99', 'XXX'))
         self.assertEqual(result, self.MoneyClass('2.99', 'XXX'))
-    
+
     def test_int(self):
         self.assertEqual(int(self.MoneyClass('-2.99', 'XXX')), -2)
         self.assertEqual(int(self.MoneyClass('2.99', 'XXX')), 2)
-    
+
     def test_float(self):
         self.assertEqual(float(self.MoneyClass('-2.99', 'XXX')), -2.99)
         self.assertEqual(float(self.MoneyClass('2.99', 'XXX')), 2.99)
-    
+
     # RADAR: Python2
     @unittest.skipIf(money.six.PY3, "Money round() behaviour is different between Python 2 and Python 3.")
     def test_round_python2(self):
         self.assertEqual(round(self.MoneyClass('-1.49', 'XXX')), -1.0)
         self.assertEqual(round(self.MoneyClass('1.50', 'XXX')), 2.0)
         self.assertEqual(round(self.MoneyClass('1.234', 'XXX'), 2), 1.23)
-    
+
     # RADAR: Python2
     @unittest.skipIf(money.six.PY2, "Money round() behaviour is different between Python 2 and Python 3.")
     def test_round_python3(self):
@@ -443,10 +443,10 @@ class NumericOperationsMixin(object):
 class UnaryOperationsReturnNewMixin(object):
     def test_pos(self):
         self.assertIsNot(+self.money, self.money)
-    
+
     def test_abs(self):
         self.assertIsNot(abs(self.money), self.money)
-    
+
     def test_round(self):
         self.assertIsNot(round(self.money), self.money)
 
@@ -455,19 +455,19 @@ class LeftmostTypePrevailsMixin(object):
     def test_add(self):
         result = self.money + self.other_money
         self.assertEqual(result.__class__, self.MoneyClass)
-    
+
     def test_add_other(self):
         result = self.other_money + self.money
         self.assertEqual(result.__class__, self.MoneySubclass)
-    
+
     def test_sub(self):
         result = self.money - self.other_money
         self.assertEqual(result.__class__, self.MoneyClass)
-    
+
     def test_sub_other(self):
         result = self.other_money - self.money
         self.assertEqual(result.__class__, self.MoneySubclass)
-    
+
 
 
 

--- a/money/tests/mixins.py
+++ b/money/tests/mixins.py
@@ -7,10 +7,13 @@ from __future__ import absolute_import
 
 import abc
 from decimal import Decimal
-import collections
 import unittest
 import pickle
 import babel
+try:
+  from collections.abc import Hashable
+except ImportError:
+  from collections import Hashable
 
 # RADAR: Python2
 import money.six
@@ -81,7 +84,7 @@ class ClassMixin(object):
             self.money.currency = 'YYY'
     
     def test_hashable(self):
-        self.assertIsInstance(self.money, collections.Hashable)
+        self.assertIsInstance(self.money, Hashable)
     
     def test_hash_eq(self):
         money_set = set([self.money, self.money])
@@ -126,7 +129,7 @@ class FormattingMixin(object):
     def test_auto_format_locales(self):
         self.assertEqual(self.money.format('en_US'), u'-$1,234.57')
         self.assertEqual(self.money.format('de_DE'), u'-1.234,57\xa0$')
-        self.assertEqual(self.money.format('es_CO'), u'-US$\xa01.234,57')
+        self.assertEqual(self.money.format('es_CO'), u'-US$1.234,57')
     
     def test_auto_format_locales_alias(self):
         self.assertEqual(self.money.format('en'), self.money.format('en_US'))

--- a/money/tests/test_xmoney.py
+++ b/money/tests/test_xmoney.py
@@ -42,11 +42,11 @@ class TestXMoneyNumericOperations(mixins.NumericOperationsMixin, unittest.TestCa
         xrates.base = 'XXX'
         xrates.setrate('AAA', Decimal('2'))
         xrates.setrate('BBB', Decimal('8'))
-    
+
     @classmethod
     def tearDownClass(cls):
         xrates.uninstall()
-    
+
     def setUp(self):
         self.MoneyClass = XMoney
         self.x = XMoney('10', 'XXX')
@@ -54,23 +54,23 @@ class TestXMoneyNumericOperations(mixins.NumericOperationsMixin, unittest.TestCa
         self.b = XMoney('10', 'BBB')
         self.ax = XMoney('20', 'AAA')
         self.bx = XMoney('80', 'BBB')
-    
+
     def test_add_money_different_currency(self):
         self.assertEqual(self.a + self.b, XMoney('12.5', 'AAA'))
         self.assertEqual(self.b + self.a, XMoney('50', 'BBB'))
-    
+
     def test_sub_money_different_currency(self):
         self.assertEqual(self.a - self.b, XMoney('7.5', 'AAA'))
         self.assertEqual(self.b - self.a, XMoney('-30', 'BBB'))
-    
+
     def test_truediv_money_different_currency(self):
         self.assertEqual(self.a / self.b, Decimal('4'))
         self.assertEqual(self.b / self.a, Decimal('0.25'))
-    
+
     def test_floordiv_money_different_currency(self):
         self.assertEqual(self.a // self.b, Decimal('4'))
         self.assertEqual(self.b // self.a, Decimal('0'))
-    
+
     def test_divmod_money_different_currency(self):
         whole, remainder = divmod(self.a, self.b)
         self.assertEqual(whole, Decimal('4'))


### PR DESCRIPTION
Hi! Thanks for the library it is very useful 😃 

Recently in my code I have started getting the following warnings:
```
.env/lib/python3.11/site-packages/money/money.py:24
<...>/.env/lib/python3.11/site-packages/money/money.py:24: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    BABEL_VERSION = StrictVersion(babel.__version__)
```

This PR updates the code to use `packaging.version` if it is available avoiding the warning. Also while I had the code there I fixed a few other tests and formatting issues.

The three commits are:
- [Replace deprecated distutils with version](https://github.com/carlospalol/money/commit/c7b60b50c54808ab5666ac45e022aec35915be63)
- [Fix a few tests](https://github.com/carlospalol/money/commit/9d5556ed170b7c7c54f5b84ae395914e6ae37690), seems like a) the es_ES, es_CO locale formats have been tweaked and b) Python moved `collections.Hashable` to `collections.abc.Hashable`
- Remove a bunch of extra whitespace

Happy to split them into separate PRs if that would be better.

Cheers!
Hector 