### PR TITLE
feat: split money into parts

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -87,6 +87,14 @@ More formally, with *AAA* and *BBB* being different currencies:
 
 Arithmetic operations with floats are not directly supported. If you need to operate with floats, you must first convert the float to a Decimal, or the Money object to a float (i.e. float(m)). Please be aware of the `issues and limitations of floating point arithmetics <https://docs.python.org/3/tutorial/floatingpoint.html>`_.
 
+You can easily split a Money object into a number of parts, ensuring that the sum of the parts equals the original amount:
+
+.. code:: python
+
+    >>> Money('10.00', 'USD').split(3)
+    [Money(3.34, "USD"), Money(3.33, "USD"), Money(3.33, "USD")]
+
+Note that the precision of the split amounts will be the same as the original amount.
 
 Currency presets
 ----------------

--- a/money/money.py
+++ b/money/money.py
@@ -290,7 +290,23 @@ class Money(object):
         else:
             raise NotImplementedError("formatting requires Babel "
                                       "(https://pypi.python.org/pypi/Babel)")
-    
+
+    def split(self, parts: int) -> list["Money"]:
+        """Return a list of n Money objects, ensuring that the sum of the parts equals the original amount.
+
+        >>> Money('10.00', "USD").split(3)
+        [Money(3.34, "USD"), Money(3.33, "USD"), Money(3.33, "USD")]
+        """
+        if parts <= 1:
+            raise ValueError("parts must be greater than 1")
+
+        precision = abs(self.amount.as_tuple().exponent)
+        base_amount = round(self / parts, precision)
+        last_parts = [base_amount for _ in range(parts - 1)]
+        first_part = self - sum(last_parts)
+
+        return [round(first_part, precision)] + last_parts
+
     @classmethod
     def loads(cls, s):
         """Parse from a string representation (repr)"""

--- a/money/tests/test_money.py
+++ b/money/tests/test_money.py
@@ -51,3 +51,7 @@ class TestMoneyLeftmostTypePrevails(mixins.LeftmostTypePrevailsMixin, unittest.T
         self.other_money = self.MoneySubclass('2.99', 'XXX')
 
 
+class TestMoneySplit(unittest.TestCase):
+    def test_split(self):
+        self.assertEqual(Money('10.00', 'USD').split(3), [Money('3.34', 'USD'), Money('3.33', 'USD'), Money('3.33', 'USD')])
+        self.assertEqual(Money('9.9999999999', 'USD'), sum(Money('9.9999999999', 'USD').split(7)))


### PR DESCRIPTION
Add a method to easily split a `Money` object into a number of parts, ensuring that the sum of the parts equals the original amount:

```python
>>> Money('10.00', 'USD').split(3)
[Money(3.34, "USD"), Money(3.33, "USD"), Money(3.33, "USD")]

>>> sum(Money('10', 'USD').split(3)) == Money('10', 'USD')
True
```

Note that the precision of the split amounts will be the same as the original amount.